### PR TITLE
Publish helm chart using GH pages

### DIFF
--- a/.github/workflows/on-push-main-publish-chart.yml
+++ b/.github/workflows/on-push-main-publish-chart.yml
@@ -1,0 +1,75 @@
+name: Publish helm chart
+
+on:
+  push:
+    branches:
+      - main
+env:
+  HELM_VERSION: v3.8.2
+
+jobs:
+  lint-chart:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0        
+          
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      # python is a requirement for the chart-testing action below (supports yamllint among other tests)
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed    
+        run: |
+          changed=$(ct list-changed)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install  
+
+  publish-chart:
+
+    runs-on: ubuntu-latest
+    needs: lint-chart
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.1.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+

--- a/.github/workflows/on-push-main-publish-chart.yml
+++ b/.github/workflows/on-push-main-publish-chart.yml
@@ -4,53 +4,15 @@ on:
   push:
     branches:
       - main
-env:
-  HELM_VERSION: v3.8.2
+    paths:
+      - 'charts/**'
+      - '.github/workflows/on-push-main-publish-chart.yml'
+  workflow_dispatch:
 
 jobs:
-  lint-chart:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0        
-          
-      - name: Set up Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: ${{ env.HELM_VERSION }}
-
-      # python is a requirement for the chart-testing action below (supports yamllint among other tests)
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
-
-      - name: Run chart-testing (list-changed)
-        id: list-changed    
-        run: |
-          changed=$(ct list-changed)
-          if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
-          fi
-
-      - name: Run chart-testing (lint)
-        run: ct lint
-
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
-        if: steps.list-changed.outputs.changed == 'true'
-
-      - name: Run chart-testing (install)
-        run: ct install  
-
   publish-chart:
 
     runs-on: ubuntu-latest
-    needs: lint-chart
 
     steps:
       - name: Checkout
@@ -63,13 +25,7 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Install Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: ${{ env.HELM_VERSION }}
-
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.1.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-

--- a/charts/k6-loadtester/Chart.yaml
+++ b/charts/k6-loadtester/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k6-loadtester
 description: Flagger webhook using k6 to do load testing of the canary before rolling out traffic
 type: application
-version: 0.0.2-pre-02
+version: 0.0.2
 appVersion: "0.1.1"
 sources:
   - https://github.com/grafana/flagger-k6-webhook

--- a/charts/k6-loadtester/Chart.yaml
+++ b/charts/k6-loadtester/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k6-loadtester
 description: Flagger webhook using k6 to do load testing of the canary before rolling out traffic
 type: application
-version: 0.0.2
+version: 0.0.3
 appVersion: "0.1.1"
 sources:
   - https://github.com/grafana/flagger-k6-webhook

--- a/charts/k6-loadtester/Chart.yaml
+++ b/charts/k6-loadtester/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k6-loadtester
 description: Flagger webhook using k6 to do load testing of the canary before rolling out traffic
 type: application
-version: 0.0.1
+version: 0.0.1-pre-01
 appVersion: "0.1.1"
 sources:
   - https://github.com/grafana/flagger-k6-webhook

--- a/charts/k6-loadtester/Chart.yaml
+++ b/charts/k6-loadtester/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k6-loadtester
 description: Flagger webhook using k6 to do load testing of the canary before rolling out traffic
 type: application
-version: 0.0.1-pre-01
+version: 0.0.1
 appVersion: "0.1.1"
 sources:
   - https://github.com/grafana/flagger-k6-webhook
@@ -11,3 +11,12 @@ keywords:
   - canary
   - webhook
   - k6
+home: https://github.com/k8s-at-home/charts/tree/master/charts/stable/autobrr
+icon: https://avatars.githubusercontent.com/u/88781313?s=200&v=4
+maintainers:
+  - name: funkypenguin
+    email: davidy@funkypenguin.co.nz
+annotations:
+  artifacthub.io/changes: |-
+    - kind: added
+      description: Initial release

--- a/charts/k6-loadtester/Chart.yaml
+++ b/charts/k6-loadtester/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k6-loadtester
 description: Flagger webhook using k6 to do load testing of the canary before rolling out traffic
 type: application
-version: 0.0.2-pre-01
+version: 0.0.2-pre-02
 appVersion: "0.1.1"
 sources:
   - https://github.com/grafana/flagger-k6-webhook

--- a/charts/k6-loadtester/Chart.yaml
+++ b/charts/k6-loadtester/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k6-loadtester
 description: Flagger webhook using k6 to do load testing of the canary before rolling out traffic
 type: application
-version: 0.0.1
+version: 0.0.2-pre-01
 appVersion: "0.1.1"
 sources:
   - https://github.com/grafana/flagger-k6-webhook

--- a/charts/k6-loadtester/templates/deployment.yaml
+++ b/charts/k6-loadtester/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       volumes:
         {{- toYaml .Values.volumes | nindent 8 }}        
       initContainers:
-{{ toYaml .Values.extraInitContainers | indent 8 }} 
+{{ toYaml .Values.InitContainers | indent 8 }} 
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/k6-loadtester/templates/deployment.yaml
+++ b/charts/k6-loadtester/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       volumes:
         {{- toYaml .Values.volumes | nindent 8 }}        
       initContainers:
-{{ toYaml .Values.InitContainers | indent 8 }} 
+{{ toYaml .Values.initContainers | indent 8 }} 
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/k6-loadtester/templates/deployment.yaml
+++ b/charts/k6-loadtester/templates/deployment.yaml
@@ -24,6 +24,11 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        {{- toYaml .Values.volumes | nindent 8 }}        
+      initContainers:
+{{ toYaml .Values.extraInitContainers | indent 8 }}
+      {{- end }}        
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -47,7 +52,9 @@ spec:
                 secretKeyRef:
                   name: {{ $.Values.webhook.name }}
                   key: {{ $k | quote }}
-            {{- end }}                        
+            {{- end }}                       
+          volumeMounts:
+            {{- toYaml .Values.volumeMounts | nindent 12 }}             
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/k6-loadtester/templates/deployment.yaml
+++ b/charts/k6-loadtester/templates/deployment.yaml
@@ -27,8 +27,7 @@ spec:
       volumes:
         {{- toYaml .Values.volumes | nindent 8 }}        
       initContainers:
-{{ toYaml .Values.extraInitContainers | indent 8 }}
-      {{- end }}        
+{{ toYaml .Values.extraInitContainers | indent 8 }} 
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/k6-loadtester/values.yaml
+++ b/charts/k6-loadtester/values.yaml
@@ -64,3 +64,13 @@ webhook:
   vars:
     "K6_CLOUD_TOKEN" : ""
     "SLACK_TOKEN" : ""
+
+# Additional volumes Deployment (can be used with initContainers, below)
+volumes: []
+
+## InitContainers allows injecting additional initContainers. This is meant to allow doing some changes
+## (permissions, dir tree) on mounted volumes before starting prometheus
+initContainers: []
+
+# Additional VolumeMounts on the Deployment
+volumeMounts: []


### PR DESCRIPTION
Hey guys!

Here's a PR to add some GitHub Actions to auto-publish the helm chart, using GitHub Pages. This means that people who use the chart in CI/CD, for example, and who can't do an install directly from helm, can still install a specific version from a URL (in this case, the chart repo would be https://grafana.github.io/flagger-k6-webhook/)

You can test it against the version I published in my fork, at https://funkypenguin.github.io/flagger-k6-webhook/ ;)

D
