### PR TITLE
Run as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,4 @@ COPY --from=build /app/flagger-k6-webhook /usr/bin/flagger-k6-webhook
 COPY --from=loadimpact/k6 /usr/bin/k6 /usr/bin/k6
 
 ENTRYPOINT /usr/bin/flagger-k6-webhook
+USER 65534

--- a/charts/k6-loadtester/Chart.yaml
+++ b/charts/k6-loadtester/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k6-loadtester
 description: Flagger webhook using k6 to do load testing of the canary before rolling out traffic
 type: application
-version: 0.0.1
+version: 1.0.0
 appVersion: "0.1.1"
 sources:
   - https://github.com/grafana/flagger-k6-webhook

--- a/charts/k6-loadtester/templates/deployment.yaml
+++ b/charts/k6-loadtester/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8000
               protocol: TCP
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}

--- a/charts/k6-loadtester/values.yaml
+++ b/charts/k6-loadtester/values.yaml
@@ -29,16 +29,16 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  fsGroup: 65534
 
 securityContext:
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65534
 
 service:
   type: ClusterIP

--- a/charts/k6-loadtester/values.yaml
+++ b/charts/k6-loadtester/values.yaml
@@ -15,7 +15,7 @@ logLevel: debug
 
 readinessProbe:
   httpGet:
-    port: 80
+    port: 8000
     path: /health
 
 serviceAccount:
@@ -42,7 +42,7 @@ securityContext:
 
 service:
   type: ClusterIP
-  port: 80
+  port: 8000
 
 resources: {}
   # limits:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultPort = 80
+	defaultPort = 8000
 
 	flagCloudToken       = "cloud-token"
 	flagLogLevel         = "log-level"

--- a/example/loadtester-deployment.yml
+++ b/example/loadtester-deployment.yml
@@ -30,9 +30,9 @@ spec:
         image: ghcr.io/grafana/flagger-k6-webhook:v0.0.4
         name: k6-loadtester
         ports:
-        - containerPort: 80
+        - containerPort: 8000
           name: http-metrics
         readinessProbe:
           httpGet:
             path: /health
-            port: 80
+            port: 8000

--- a/example/loadtester-service.yml
+++ b/example/loadtester-service.yml
@@ -5,8 +5,8 @@ metadata:
   namespace: flagger
 spec:
   ports:
-  - name: k6-loadtester-http-metrics
-    port: 80
-    targetPort: 80
+  - name: http-k6-loadtester-metrics
+    port: 8000
+    targetPort: 8000
   selector:
     name: k6-loadtester


### PR DESCRIPTION
Hey guys!

This PR simply changes the webhook from running on port 80 to running on port 8000, which means it no longer requires running as root! I've updated the helm chart and Dockerfile to use alpine's "nobody" user (UID 65534), which should make it compatible with platforms (like mine!) which enforce non-root users on all containers :)

Cheers!
D