### PR TITLE
Align chart's appVersion with release syntax

### DIFF
--- a/charts/k6-loadtester/Chart.yaml
+++ b/charts/k6-loadtester/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: k6-loadtester
 description: Flagger webhook using k6 to do load testing of the canary before rolling out traffic
 type: application
-version: 1.0.0
-appVersion: "0.1.1"
+version: 1.0.1
+appVersion: "k6-loadtester-1.0.1"
 sources:
   - https://github.com/grafana/flagger-k6-webhook
 keywords:
@@ -16,5 +16,7 @@ maintainers:
   - name: julienduchesne
 annotations:
   artifacthub.io/changes: |-
+    - kind: updated
+      description: Aligned appVersion with release syntax
     - kind: added
       description: Initial release

--- a/charts/k6-loadtester/values.yaml
+++ b/charts/k6-loadtester/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/grafana/flagger-k6-webhook
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.1.1"
+  tag: ""
 
 # accepted values are debug, info, warning, error (defaults to info)
 logLevel: debug


### PR DESCRIPTION
Hey guys,

This PR aligns the chart's appVersion with the tag syntax used for the images built (*prefixing the version with `k6-loadtester-`*), assuming that this was an intentional configuration :)

The PR also bumps the chart version to 1.0.1, which is necessary to trigger chart-releaser to actually release the chart (see the succeeded-but-not-really publish action [here](https://github.com/grafana/flagger-k6-webhook/actions/runs/2978535490))

Cheers!
D