### PR TITLE
docs: clarify webhook url segments and include port

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ spec:
     - name: k6-load-test
       timeout: 5m
       type: pre-rollout
-      url: http://k6-loadtester.flagger/launch-test
+      url: http://<k6_loadtester_service_name>.<k6_loadtester_namespace>:<k6_loadtester_service_port>/launch-test
       metadata:
         script: |
           import http from 'k6/http';
@@ -43,7 +43,7 @@ spec:
           };
 
           export default function () {
-            http.get('http://<your_service>-canary.<namespace>:80/');
+            http.get('http://<your_service>-canary.<namespace>:<service_port>/');
             sleep(0.10);
           }
         upload_to_cloud: "true"

--- a/example/canary.yml
+++ b/example/canary.yml
@@ -42,7 +42,7 @@ spec:
       name: k6-load-test
       timeout: 5m
       type: pre-rollout
-      url: http://k6-loadtester.flagger/launch-test
+      url: http://k6-loadtester.flagger:8000/launch-test
   autoscalerRef:
     apiVersion: autoscaling/v2beta2
     kind: HorizontalPodAutoscaler


### PR DESCRIPTION
When deploying this webhook service, we noticed that the url specified in the docs was missing the port which is assigned by default in the code. If left unspecified, http will assume port 80, however the code defaults to port 8000 unless explicitly set otherwise. This also clarifies the strucuture of the url segments in the webhook.