### PR TITLE
add serviceaccount and rbac

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ See [the example directory](./example) for a full example on how the loadtester 
 ## How to deploy using Helm
 
 ```
-helm repo add [repo/chart name]
+helm repo add flagger-k6-webhook https://grafana.github.io/flagger-k6-webhook 
 
-helm upgrade -i k6-loadtester [repo/chart name]
+helm upgrade -i k6-loadtester flagger-k6-webhook
 --namespace=flagger
 --set webhook.vars.K6_CLOUD_TOKEN=token
 --set webhook.vars.SLACK_TOKEN=slack_token

--- a/charts/k6-loadtester/Chart.yaml
+++ b/charts/k6-loadtester/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k6-loadtester
 description: Flagger webhook using k6 to do load testing of the canary before rolling out traffic
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "v0.2.0"
 sources:
   - https://github.com/grafana/flagger-k6-webhook

--- a/charts/k6-loadtester/templates/deployment.yaml
+++ b/charts/k6-loadtester/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "k6-loadtester.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:

--- a/charts/k6-loadtester/templates/rbac.yaml
+++ b/charts/k6-loadtester/templates/rbac.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.serviceAccount.rbac }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "k6-loadtester.fullname" . }}
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["secrets"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "k6-loadtester.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "k6-loadtester.serviceAccountName" . }}
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role 
+  name: {{ include "k6-loadtester.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/k6-loadtester/templates/serviceaccount.yaml
+++ b/charts/k6-loadtester/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "k6-loadtester.serviceAccountName" . }}
+  labels:
+    {{- include "k6-loadtester.labels" . | nindent 4 }}
+  annotations: {{ .Values.serviceAccount.annotations | toYaml}}
+{{- end }}

--- a/charts/k6-loadtester/values.yaml
+++ b/charts/k6-loadtester/values.yaml
@@ -26,6 +26,8 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+  # Will create Role/Rolebinding for serviceAccount to read secrets in current namespace.
+  rbac: true
 
 podAnnotations: {}
 
@@ -62,8 +64,10 @@ webhook:
   name: "k6-loadtester"
   # A list of configurable variables
   vars:
-    "K6_CLOUD_TOKEN" : ""
-    "SLACK_TOKEN" : ""
+    # "K6_CLOUD_TOKEN" : ""
+    # "SLACK_TOKEN" : ""
+    # if you need to access secrets in the cluster, use this environment value.
+    "KUBERNETES_CLIENT": "in-cluster"
 
 # Additional volumes Deployment (can be used with initContainers, below)
 volumes: []


### PR DESCRIPTION
Add serviceAccount and Rbac rules to be able to read kubernetes secrets.  

Also add undocumented option `KUBERNETES_CLIENT": "in-cluster"` as a default, this allows the service to read secrets it seems. Makes sense in a Helm chart IMO. 