### PR TITLE
fix: Add support for new cloud URLs

### DIFF
--- a/pkg/handlers/launch.go
+++ b/pkg/handlers/launch.go
@@ -26,8 +26,8 @@ const (
 	emojiFailure = ":red_circle:"
 )
 
-// https://regex101.com/r/Pn7VUB/1
-var outputRegex = regexp.MustCompile(`output: cloud \((?P<url>https:\/\/app\.k6\.io\/runs\/\d+)\)`)
+// https://regex101.com/r/OZwd8Y/1
+var outputRegex = regexp.MustCompile(`output: cloud \((?P<url>https:\/\/((app\.k6\.io)|([^/]+\.grafana.net\/a\/k6-app))\/runs\/\d+)\)`)
 
 type launchPayload struct {
 	flaggerWebhook

--- a/pkg/handlers/testdata/k6-output-legacy.txt
+++ b/pkg/handlers/testdata/k6-output-legacy.txt
@@ -7,7 +7,7 @@
 
   execution: local
      script: /tmp/k6-script504149289
-     output: cloud (https://somewhere.grafana.net/a/k6-app/runs/1157843)
+     output: cloud (https://app.k6.io/runs/1157843)
 
   scenarios: (100.00%) 1 scenario, 2 max VUs, 1m0s max duration (incl. graceful stop):
            * default: 2 looping VUs for 30s (gracefulStop: 30s)


### PR DESCRIPTION
This fixes an issue with cloud runs not being analysed properly if they are running on a k6 instance bound to a Grafana Cloud instance.