### PR TITLE
Switch to the grafana/k6 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /app/f
 FROM alpine:3.18
 
 COPY --from=build /app/flagger-k6-webhook /usr/bin/flagger-k6-webhook
-COPY --from=loadimpact/k6 /usr/bin/k6 /usr/bin/k6
+COPY --from=grafana/k6 /usr/bin/k6 /usr/bin/k6
 
 ENTRYPOINT /usr/bin/flagger-k6-webhook
 USER 65534


### PR DESCRIPTION
The `loadimpact/k6` image is deprecated and will stop receive updates after Dec 31, 2023. The `grafana/k6` image is fully compatible and there are no other steps needed to migrate besides changing the image name.

Ref PR https://github.com/grafana/k6/pull/3494