### PR TITLE
chore: Fix make build for non-x86 machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ dev:
 	go build -o ./flagger-k6-webhook cmd/main.go
 
 build:
-	docker build -t $(IMAGE) .
+	docker build --platform=linux/amd64 -t $(IMAGE) .
 	docker tag $(IMAGE) $(IMAGE):$(VERSION)
 
 push: build


### PR DESCRIPTION
Seems like loadimpact/k6 is not available for linux/amd64