### PR TITLE
Remove apiGroup for ServiceAccount RoleBinding subject

### DIFF
--- a/charts/k6-loadtester/templates/rbac.yaml
+++ b/charts/k6-loadtester/templates/rbac.yaml
@@ -15,9 +15,8 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ include "k6-loadtester.serviceAccountName" . }}
-  apiGroup: rbac.authorization.k8s.io
 roleRef:
-  kind: Role 
+  kind: Role
   name: {{ include "k6-loadtester.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}


### PR DESCRIPTION
closes: https://github.com/grafana/flagger-k6-webhook/issues/126

See the referenced issue, but essentially when installing this i get the following when keeping the `apiGroup` for a ServiceAccount subject

> Error: UPGRADE FAILED: failed to create resource: RoleBinding.rbac.authorization.k8s.io "k6-loadtester" is invalid: subjects[0].apiGroup: Unsupported value: "rbac.authorization.k8s.io": supported values: ""


Additionally, the README should be (note addition of `k6-loadtester` after the helm-repository):

```sh
helm upgrade -i k6-loadtester flagger-k6-webhook/k6-loadtester
--namespace=flagger
--set webhook.vars.K6_CLOUD_TOKEN=token
--set webhook.vars.SLACK_TOKEN=slack_token
```