### PR TITLE
feat: Generate linux/amd64 and linux/arm64 images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,13 +31,28 @@ jobs:
         # project is not that large:
         fetch-depth: 0
 
-    - name: Build Docker Image
-      run: make build
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
-    - name: Push Docker Image
-      if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
-      run: make push
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
-    - name: Push Latest Docker Image
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: make push-latest
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+      with:
+        images: ghcr.io/grafana/flagger-k6-webhook
+        tags: |
+          type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+          type=raw,value={{tag}},enable=${{ github.ref == 'refs/tags' && github.event_name == 'push' }}
+          type=sha,enable=${{ github.event_name == 'pull_request' }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
+      with:
+        platforms: |
+          linux/amd64
+          linux/arm64
+        push: ${{ github.event_name != 'pull_request' }}
+        tags: ${{ steps.meta.outputs.tags }}
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,51 +8,135 @@ on:
     branches:
       - main
 
+env:
+  REGISTRY_IMAGE: ghcr.io/grafana/flagger-k6-webhook
+  TAG_CONFIG: |
+    type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+    type=raw,value={{tag}},enable=${{ github.ref == 'refs/tags' && github.event_name == 'push' }}
+    type=sha,enable=${{ github.event_name == 'pull_request' }}
+
 jobs:
-  docker:
+  # We create a docker image per platform in this first step:
+  build:
+    strategy:
+      fail-fast: false
+      # Based on
+      # https://github.com/orgs/community/discussions/26253#discussioncomment-6745038
+      # we only want amd64 images to be built for PRs to speed up the feedback
+      # loop:
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+        isPR:
+          - ${{ github.event_name == 'pull_request' }}
+        include:
+          - platform: linux/amd64
+        exclude:
+          - isPR: true
+
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      packages: write
-
     steps:
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Checkout Repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          # Workaround for https://github.com/actions/checkout/issues/1467 as the
+          # project is not that large:
+          fetch-depth: 0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: ${{ env.TAG_CONFIG }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
+        with:
+          platforms: ${{ matrix.platform }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Export digest
+        id: digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"          
+          echo "artifact_name=digests-${{ matrix.platform }}" | sed -e 's/\//-/g' >> "$GITHUB_OUTPUT"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: ${{ steps.digest.outputs.artifact_name }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    needs: 
+      - build
+    steps:
+      - name: Download digests (linux/amd64)
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        with:
+          name: digests-linux-amd64
+          path: /tmp/digests-linux-amd64
+
+      - name: Download digests (linux/arm64)
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        with:
+          name: digests-linux-arm64
+          path: /tmp/digests-linux-arm64
+
+      - name: Merge digests
+        run: |
+          mkdir -p /tmp/digests
+          cp /tmp/digests-linux-amd64/* /tmp/digests/
+          cp /tmp/digests-linux-arm64/* /tmp/digests/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
     
-    - name: Checkout Repository
-      uses: actions/checkout@v4
-      with:
-        # Workaround for https://github.com/actions/checkout/issues/1467 as the
-        # project is not that large:
-        fetch-depth: 0
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: ${{ env.TAG_CONFIG }}
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)          
 
-    - name: Extract metadata (tags, labels) for Docker
-      id: meta
-      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
-      with:
-        images: ghcr.io/grafana/flagger-k6-webhook
-        tags: |
-          type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
-          type=raw,value={{tag}},enable=${{ github.ref == 'refs/tags' && github.event_name == 'push' }}
-          type=sha,enable=${{ github.event_name == 'pull_request' }}
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
-      with:
-        platforms: |
-          linux/amd64
-          linux/arm64
-        push: ${{ github.event_name != 'pull_request' }}
-        tags: ${{ steps.meta.outputs.tags }}
-
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}  

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,4 @@
-.PHONY: dev build push push-latest
-VERSION := $(shell git describe --tags --dirty --always)
-IMAGE ?= ghcr.io/grafana/flagger-k6-webhook
+.PHONY: dev
 
 dev:
 	go build -o ./flagger-k6-webhook cmd/main.go
-
-build:
-	docker build --platform=linux/amd64 -t $(IMAGE) .
-	docker tag $(IMAGE) $(IMAGE):$(VERSION)
-
-push: build
-	docker push $(IMAGE):$(VERSION)
-
-push-latest: build
-	docker push $(IMAGE)


### PR DESCRIPTION
GitHub workflow based approach to generate linux/amd64 & linux/arm64 images. For PRs only the linux/amd64 image should be built but nothing uploaded.

The implementation is based on what is done in grafana/tanka.

Partial of https://github.com/grafana/flagger-k6-webhook/issues/128