### PR TITLE
Bump chart version to enable publishing

### DIFF
--- a/charts/k6-loadtester/Chart.yaml
+++ b/charts/k6-loadtester/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k6-loadtester
 description: Flagger webhook using k6 to do load testing of the canary before rolling out traffic
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: "v0.2.0"
 sources:
   - https://github.com/grafana/flagger-k6-webhook
@@ -17,4 +17,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |-
     - kind: updated
-      description: Update appVersion to v0.2.0
+      description: Remove apiGroup for ServiceAccount RoleBinding subject


### PR DESCRIPTION
Enables the publishing of the work from https://github.com/grafana/flagger-k6-webhook/pull/127