### PR TITLE
fix: Register processes for cleanup

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,7 @@ jobs:
         run: go build ./...
 
       - name: Test
-        run: go test ./...
+        run: go test ./... -race
 
       - name: Lint
         uses: golangci/golangci-lint-action@v6

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,13 +14,15 @@ import (
 )
 
 const (
-	defaultPort = 8000
+	defaultPort               = 8000
+	defaultMaxProcessHandlers = 100
 
-	flagCloudToken       = "cloud-token"
-	flagLogLevel         = "log-level"
-	flagListenPort       = "listen-port"
-	flagSlackToken       = "slack-token"
-	flagKubernetesClient = "kubernetes-client"
+	flagCloudToken         = "cloud-token"
+	flagLogLevel           = "log-level"
+	flagListenPort         = "listen-port"
+	flagSlackToken         = "slack-token"
+	flagKubernetesClient   = "kubernetes-client"
+	flagMaxProcessHandlers = "max-process-handlers"
 
 	kubernetesClientNone      = "none"
 	kubernetesClientInCluster = "in-cluster"
@@ -63,6 +65,11 @@ func run(args []string) error {
 			Value:   kubernetesClientNone,
 			Usage:   fmt.Sprintf("Kubernetes client to use: '%s' or '%s'", kubernetesClientInCluster, kubernetesClientNone),
 		},
+		&cli.IntFlag{
+			Name:    flagMaxProcessHandlers,
+			EnvVars: []string{"MAX_PROCESS_HANDLERS"},
+			Value:   defaultMaxProcessHandlers,
+		},
 	}
 
 	return app.Run(args)
@@ -95,5 +102,5 @@ func launchServer(c *cli.Context) error {
 		log.Info("not creating a kubernetes client")
 	}
 
-	return pkg.Listen(client, kubeClient, slackClient, c.Int(flagListenPort))
+	return pkg.Listen(client, kubeClient, slackClient, c.Int(flagListenPort), c.Int(flagMaxProcessHandlers))
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,14 +18,14 @@ import (
 
 const (
 	defaultPort               = 8000
-	defaultMaxProcessHandlers = 100
+	defaultMaxConcurrentTests = 1000
 
 	flagCloudToken         = "cloud-token"
 	flagLogLevel           = "log-level"
 	flagListenPort         = "listen-port"
 	flagSlackToken         = "slack-token"
 	flagKubernetesClient   = "kubernetes-client"
-	flagMaxProcessHandlers = "max-process-handlers"
+	flagMaxConcurrentTests = "max-concurrent-tests"
 
 	kubernetesClientNone      = "none"
 	kubernetesClientInCluster = "in-cluster"
@@ -71,9 +71,9 @@ func run(args []string) error {
 			Usage:   fmt.Sprintf("Kubernetes client to use: '%s' or '%s'", kubernetesClientInCluster, kubernetesClientNone),
 		},
 		&cli.IntFlag{
-			Name:    flagMaxProcessHandlers,
-			EnvVars: []string{"MAX_PROCESS_HANDLERS"},
-			Value:   defaultMaxProcessHandlers,
+			Name:    flagMaxConcurrentTests,
+			EnvVars: []string{"MAX_CONCURRENT_TESTS"},
+			Value:   defaultMaxConcurrentTests,
 		},
 	}
 
@@ -108,5 +108,5 @@ func launchServer(c *cli.Context) error {
 		log.Info("not creating a kubernetes client")
 	}
 
-	return pkg.Listen(ctx, client, kubeClient, slackClient, c.Int(flagListenPort), c.Int(flagMaxProcessHandlers))
+	return pkg.Listen(ctx, client, kubeClient, slackClient, c.Int(flagListenPort), c.Int(flagMaxConcurrentTests))
 }

--- a/pkg/handlers/launch.go
+++ b/pkg/handlers/launch.go
@@ -210,7 +210,7 @@ func NewLaunchHandler(ctx context.Context, client k6.Client, kubeClient kubernet
 		Name:       "launch_test_duration",
 		Help:       "Durations of the executed k6 test run in seconds",
 		Objectives: map[float64]float64{0.5: float64(30)},
-	}, []string{"exitCode"})
+	}, []string{"exit_code"})
 	h.metricTestDuration = metricTestDuration
 	h.metricsRegistry = prometheus.NewRegistry()
 	_ = h.metricsRegistry.Register(h.metricTestDuration)
@@ -466,7 +466,7 @@ func (h *launchHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 
 func (h *launchHandler) trackExecutionDuration(cmd k6.TestRun) {
 	if dur := cmd.ExecutionDuration(); dur != 0 {
-		h.metricTestDuration.With(prometheus.Labels{"exitCode": fmt.Sprintf("%d", cmd.ExitCode())}).Observe(float64(dur / time.Second))
+		h.metricTestDuration.With(prometheus.Labels{"exit_code": fmt.Sprintf("%d", cmd.ExitCode())}).Observe(float64(dur / time.Second))
 	}
 }
 

--- a/pkg/handlers/launch.go
+++ b/pkg/handlers/launch.go
@@ -308,13 +308,14 @@ func (h *launchHandler) buildEnvVars(payload *launchPayload) (map[string]string,
 }
 
 func (h *launchHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	cmdLog := createLogEntry(req)
 	select {
 	case <-h.availableTestRuns:
 	default:
+		cmdLog.Warn("Maximum concurrent test runs reached. Rejecting request.")
 		http.Error(resp, "Maximum concurrent test runs reached", http.StatusTooManyRequests)
 		return
 	}
-	cmdLog := createLogEntry(req)
 	logIfError := func(err error) {
 		if err != nil {
 			cmdLog.Error(err)

--- a/pkg/handlers/launch.go
+++ b/pkg/handlers/launch.go
@@ -188,6 +188,8 @@ func (h *launchHandler) Close() {
 }
 
 // context exposes the internal context for testing purposes.
+//
+//nolint:unused
 func (h *launchHandler) context() context.Context {
 	return h.ctx
 }
@@ -224,7 +226,7 @@ loop:
 				log.Debugf("process handler available")
 				wg.Add(1)
 				go func() {
-					h.waitForProcess(ctx, cmd)
+					h.waitForProcess(cmd)
 					availableProcessHandlers <- struct{}{}
 					wg.Done()
 				}()
@@ -237,7 +239,7 @@ loop:
 	close(availableProcessHandlers)
 }
 
-func (h *launchHandler) waitForProcess(ctx context.Context, cmd k6.TestRun) {
+func (h *launchHandler) waitForProcess(cmd k6.TestRun) {
 	if cmd == nil {
 		log.Warnf("nil as testrun passed")
 		return

--- a/pkg/handlers/launch.go
+++ b/pkg/handlers/launch.go
@@ -311,7 +311,7 @@ func (h *launchHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	select {
 	case <-h.availableTestRuns:
 	default:
-		http.Error(resp, "Maximum concurrent test runs reached", 429)
+		http.Error(resp, "Maximum concurrent test runs reached", http.StatusTooManyRequests)
 		return
 	}
 	cmdLog := createLogEntry(req)

--- a/pkg/handlers/launch.go
+++ b/pkg/handlers/launch.go
@@ -186,7 +186,9 @@ func NewLaunchHandler(ctx context.Context, client k6.Client, kubeClient kubernet
 		Help: "The maximum number of concurrent tests",
 	})
 	metricMaxConcurrentTests.Set(float64(maxConcurrentTests))
-	prometheus.Register(metricMaxConcurrentTests)
+	if err := prometheus.Register(metricMaxConcurrentTests); err != nil {
+		log.Warnf("Failed to register new metric: %s", err.Error())
+	}
 
 	metricAvailableConcurrentTests := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "launch_available_concurrent_tests",
@@ -194,7 +196,9 @@ func NewLaunchHandler(ctx context.Context, client k6.Client, kubeClient kubernet
 	}, func() float64 {
 		return float64(len(h.availableTestRuns))
 	})
-	prometheus.Register(metricAvailableConcurrentTests)
+	if err := prometheus.Register(metricAvailableConcurrentTests); err != nil {
+		log.Warnf("Failed to register new metric: %s", err.Error())
+	}
 
 	go h.waitForProcesses(ctx)
 	return h, nil

--- a/pkg/handlers/launch.go
+++ b/pkg/handlers/launch.go
@@ -25,6 +25,8 @@ const (
 	emojiSuccess = ":large_green_circle:"
 	emojiWarning = ":warning:"
 	emojiFailure = ":red_circle:"
+
+	metricTestDurationName = "launch_test_duration"
 )
 
 // https://regex101.com/r/OZwd8Y/1
@@ -207,7 +209,7 @@ func NewLaunchHandler(ctx context.Context, client k6.Client, kubeClient kubernet
 	// expected wait time in case the maximum number of concurrent tests is
 	// reached:
 	metricTestDuration := prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Name:       "launch_test_duration",
+		Name:       metricTestDurationName,
 		Help:       "Durations of the executed k6 test run in seconds",
 		Objectives: map[float64]float64{0.5: float64(30)},
 	}, []string{"exit_code"})
@@ -329,7 +331,7 @@ func (h *launchHandler) getWaitTime() int64 {
 		return 60
 	}
 	for _, family := range families {
-		if family.GetName() == "launch_test_duration" {
+		if family.GetName() == metricTestDurationName {
 			for _, metric := range family.GetMetric() {
 				for _, quantile := range metric.GetSummary().GetQuantile() {
 					if quantile.GetQuantile() == 0.5 {

--- a/pkg/handlers/launch.go
+++ b/pkg/handlers/launch.go
@@ -172,7 +172,7 @@ func NewLaunchHandler(ctx context.Context, client k6.Client, kubeClient kubernet
 		slackClient:          slackClient,
 		lastFailureTime:      make(map[string]time.Time),
 		sleep:                time.Sleep,
-		processToWaitFor:     make(chan k6.TestRun, 1),
+		processToWaitFor:     make(chan k6.TestRun, maxConcurrentTests),
 		waitForProcessesDone: make(chan struct{}, 1),
 		ctx:                  ctx,
 	}

--- a/pkg/handlers/launch_test.go
+++ b/pkg/handlers/launch_test.go
@@ -655,7 +655,7 @@ func setupHandlerWithKubernetesObjects(t *testing.T, expectedKubernetesObjects .
 	kubeClient := fake.NewSimpleClientset(expectedKubernetesObjects...)
 	slackClient := mocks.NewMockSlackClient(mockCtrl)
 	testRun := mocks.NewMockK6TestRun(mockCtrl)
-	handler, err := NewLaunchHandler(k6Client, kubeClient, slackClient)
+	handler, err := NewLaunchHandler(k6Client, kubeClient, slackClient, 100)
 	handler.(*launchHandler).sleep = func(d time.Duration) {}
 	require.NoError(t, err)
 

--- a/pkg/handlers/launch_test.go
+++ b/pkg/handlers/launch_test.go
@@ -178,7 +178,7 @@ func TestLaunchAndWaitCloud(t *testing.T) {
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
 			// Initialize controller
-			_, cancel, _, k6Client, slackClient, testRun, handler := setupHandler(t)
+			_, cancel, _, k6Client, slackClient, testRun, handler := setupHandler(t, 100)
 			t.Cleanup(handler.Wait)
 			t.Cleanup(cancel)
 
@@ -234,7 +234,7 @@ func TestLaunchAndWaitCloud(t *testing.T) {
 
 func TestSlackFailuresDontAbort(t *testing.T) {
 	// Initialize controller
-	_, cancel, _, k6Client, slackClient, testRun, handler := setupHandler(t)
+	_, cancel, _, k6Client, slackClient, testRun, handler := setupHandler(t, 100)
 	t.Cleanup(handler.Wait)
 	t.Cleanup(cancel)
 
@@ -275,7 +275,7 @@ func TestSlackFailuresDontAbort(t *testing.T) {
 
 func TestLaunchAndWaitLocal(t *testing.T) {
 	// Initialize controller
-	_, cancel, _, k6Client, slackClient, testRun, handler := setupHandler(t)
+	_, cancel, _, k6Client, slackClient, testRun, handler := setupHandler(t, 100)
 	t.Cleanup(handler.Wait)
 	t.Cleanup(cancel)
 
@@ -344,7 +344,7 @@ func TestLaunchAndWaitLocal(t *testing.T) {
 
 func TestLaunchAndWaitAndGetError(t *testing.T) {
 	// Initialize controller
-	_, cancel, _, k6Client, slackClient, testRun, handler := setupHandler(t)
+	_, cancel, _, k6Client, slackClient, testRun, handler := setupHandler(t, 100)
 	t.Cleanup(handler.Wait)
 	t.Cleanup(cancel)
 
@@ -413,7 +413,7 @@ func TestLaunchAndWaitAndGetError(t *testing.T) {
 
 func TestLaunchNeverStarted(t *testing.T) {
 	// Initialize controller
-	_, cancel, _, k6Client, slackClient, testRun, handler := setupHandler(t)
+	_, cancel, _, k6Client, slackClient, testRun, handler := setupHandler(t, 100)
 	t.Cleanup(handler.Wait)
 	t.Cleanup(cancel)
 
@@ -465,7 +465,7 @@ func TestLaunchNeverStarted(t *testing.T) {
 
 func TestLaunchWithoutWaiting(t *testing.T) {
 	// Initialize controller
-	_, cancel, _, k6Client, slackClient, testRun, handler := setupHandler(t)
+	_, cancel, _, k6Client, slackClient, testRun, handler := setupHandler(t, 100)
 	t.Cleanup(handler.Wait)
 	t.Cleanup(cancel)
 
@@ -504,7 +504,7 @@ func TestLaunchWithoutWaiting(t *testing.T) {
 
 func TestBadPayload(t *testing.T) {
 	// Initialize controller
-	_, cancel, _, _, _, _, handler := setupHandler(t)
+	_, cancel, _, _, _, _, handler := setupHandler(t, 100)
 	t.Cleanup(handler.Wait)
 	t.Cleanup(cancel)
 
@@ -601,7 +601,7 @@ func TestEnvVars(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Initialize controller
-			_, cancel, _, k6Client, slackClient, testRun, handler := setupHandlerWithKubernetesObjects(t, tc.kubernetesObjects...)
+			_, cancel, _, k6Client, slackClient, testRun, handler := setupHandlerWithKubernetesObjects(t, 100, tc.kubernetesObjects...)
 			if tc.nilKubeClient {
 				handler.kubeClient = nil
 			}
@@ -658,10 +658,13 @@ func TestEnvVars(t *testing.T) {
 
 func TestProcessHandler(t *testing.T) {
 	t.Run("waits on processes", func(t *testing.T) {
-		_, cancel, ctrl, _, _, _, handler := setupHandler(t)
+		logrus.SetLevel(logrus.DebugLevel)
+		_, cancel, ctrl, _, _, _, handler := setupHandler(t, 100)
+		t.Log("Starting up")
 		// Now let's produce a handful of test runs and check that they are waited
 		// on
 		for range 10 {
+			<-handler.availableTestRuns
 			tr := mocks.NewMockK6TestRun(ctrl)
 			tr.EXPECT().PID().Return(-1).AnyTimes()
 			tr.EXPECT().Kill().Return(nil).AnyTimes()
@@ -671,21 +674,24 @@ func TestProcessHandler(t *testing.T) {
 			handler.registerProcessCleanup(tr)
 		}
 		time.Sleep(time.Second * 2)
+		t.Log("Cancelling handler")
 		cancel()
 		handler.Wait()
 	})
 
 	t.Run("kills process if handler is closed", func(t *testing.T) {
 		logrus.SetLevel(logrus.DebugLevel)
-		ctx, cancelCtx, _, _, _, _, handler := setupHandler(t)
+		ctx, cancelCtx, _, _, _, _, handler := setupHandler(t, 100)
 		cmd := exec.CommandContext(ctx, "sleep", "10")
 		require.NoError(t, cmd.Start())
+		<-handler.availableTestRuns
 		handler.registerProcessCleanup(&k6.DefaultTestRun{Cmd: cmd})
 
 		// Also register a process that will be done by the time we are closing
 		// the handler:
 		cmdSuccess := exec.Command("true")
 		require.NoError(t, cmdSuccess.Start())
+		<-handler.availableTestRuns
 		handler.registerProcessCleanup(&k6.DefaultTestRun{Cmd: cmdSuccess})
 
 		// Yield so that the handler can actually pick up the process:
@@ -698,11 +704,62 @@ func TestProcessHandler(t *testing.T) {
 	})
 }
 
-func setupHandler(t *testing.T) (context.Context, context.CancelFunc, *gomock.Controller, *mocks.MockK6Client, *mocks.MockSlackClient, *mocks.MockK6TestRun, *launchHandler) {
-	return setupHandlerWithKubernetesObjects(t)
+// If we get too many concurrent test requests, a 429 should be returned by the
+// ServeHTTP method.
+func Test429OnExcessiveRequests(t *testing.T) {
+	logrus.SetLevel(logrus.DebugLevel)
+	// Initialize controller
+	_, cancel, ctrl, k6Client, slackClient, testRun1, handler := setupHandler(t, 1)
+	t.Cleanup(handler.Wait)
+	t.Cleanup(cancel)
+
+	slackClient.EXPECT().SendMessages(nil, gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	slackClient.EXPECT().AddFileToThreads(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	_, resultParts := getTestOutputFromFile(t, "testdata/k6-output.txt")
+
+	// The first request should go through but the second should be rejected
+	// with a 429 response as it would exceed the concurrent testrun limit:
+	request1 := &http.Request{
+		Body: io.NopCloser(strings.NewReader(`{"name": "hello", "namespace": "default", "phase": "somephase", "metadata": {"upload_to_cloud": "false", "wait_for_results": "false", "script": "import { sleep } from 'k6'; export default function() { sleep(10) }"}}`)),
+	}
+
+	var bufferWriter1 io.Writer
+	k6Client.EXPECT().Start(gomock.Any(), gomock.Any(), false, gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, scriptContent string, upload bool, envVars map[string]string, outputWriter io.Writer) (k6.TestRun, error) {
+		bufferWriter1 = outputWriter
+		outputWriter.Write([]byte(resultParts[0]))
+		return testRun1, nil
+	}).AnyTimes()
+	testRun1.EXPECT().PID().Return(-1).AnyTimes()
+	testRun1.EXPECT().Wait().DoAndReturn(func() error {
+		time.Sleep(time.Second * 2)
+		bufferWriter1.Write([]byte("running" + resultParts[1]))
+		return nil
+	}).AnyTimes()
+	rr1 := httptest.NewRecorder()
+	handler.ServeHTTP(rr1, request1)
+	require.Equal(t, 200, rr1.Code)
+
+	testRun2 := mocks.NewMockK6TestRun(ctrl)
+	request2 := &http.Request{
+		Body: io.NopCloser(strings.NewReader(`{"name": "hello", "namespace": "default", "phase": "somephase", "metadata": {"upload_to_cloud": "false", "wait_for_results": "false", "script": "import { sleep } from 'k6'; export default function() { sleep(10) }"}}`)),
+	}
+
+	// All these mock calls should actually never happen as the request is rejected right away
+	k6Client.EXPECT().Start(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	testRun2.EXPECT().PID().Return(-1).Times(0)
+	testRun2.EXPECT().Wait().Times(0)
+
+	rr2 := httptest.NewRecorder()
+	handler.ServeHTTP(rr2, request2)
+	require.Equal(t, 429, rr2.Code)
 }
 
-func setupHandlerWithKubernetesObjects(t *testing.T, expectedKubernetesObjects ...runtime.Object) (context.Context, context.CancelFunc, *gomock.Controller, *mocks.MockK6Client, *mocks.MockSlackClient, *mocks.MockK6TestRun, *launchHandler) {
+func setupHandler(t *testing.T, maxConcurrentTests int) (context.Context, context.CancelFunc, *gomock.Controller, *mocks.MockK6Client, *mocks.MockSlackClient, *mocks.MockK6TestRun, *launchHandler) {
+	return setupHandlerWithKubernetesObjects(t, maxConcurrentTests)
+}
+
+func setupHandlerWithKubernetesObjects(t *testing.T, maxConcurrentTests int, expectedKubernetesObjects ...runtime.Object) (context.Context, context.CancelFunc, *gomock.Controller, *mocks.MockK6Client, *mocks.MockSlackClient, *mocks.MockK6TestRun, *launchHandler) {
 	t.Helper()
 
 	mockCtrl := gomock.NewController(t)
@@ -711,7 +768,7 @@ func setupHandlerWithKubernetesObjects(t *testing.T, expectedKubernetesObjects .
 	slackClient := mocks.NewMockSlackClient(mockCtrl)
 	testRun := mocks.NewMockK6TestRun(mockCtrl)
 	ctx, cancel := context.WithCancel(context.Background())
-	handler, err := NewLaunchHandler(ctx, k6Client, kubeClient, slackClient, 100)
+	handler, err := NewLaunchHandler(ctx, k6Client, kubeClient, slackClient, maxConcurrentTests)
 	handler.(*launchHandler).sleep = func(d time.Duration) {}
 	require.NoError(t, err)
 

--- a/pkg/k6/cmd.go
+++ b/pkg/k6/cmd.go
@@ -1,6 +1,7 @@
 package k6
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -44,7 +45,7 @@ func (tr *DefaultTestRun) Exited() bool {
 	return false
 }
 
-func (c *LocalRunnerClient) Start(scriptContent string, upload bool, envVars map[string]string, outputWriter io.Writer) (TestRun, error) {
+func (c *LocalRunnerClient) Start(ctx context.Context, scriptContent string, upload bool, envVars map[string]string, outputWriter io.Writer) (TestRun, error) {
 	tempFile, err := os.CreateTemp("", "k6-script")
 	if err != nil {
 		return nil, fmt.Errorf("could not create a tempfile for the script: %w", err)
@@ -59,7 +60,7 @@ func (c *LocalRunnerClient) Start(scriptContent string, upload bool, envVars map
 	}
 	args = append(args, tempFile.Name())
 
-	cmd := c.cmd("k6", args...)
+	cmd := c.cmd(ctx, "k6", args...)
 	cmd.Stdout = outputWriter
 	cmd.Stderr = outputWriter
 
@@ -72,8 +73,8 @@ func (c *LocalRunnerClient) Start(scriptContent string, upload bool, envVars map
 	return &DefaultTestRun{cmd}, cmd.Start()
 }
 
-func (c *LocalRunnerClient) cmd(name string, arg ...string) *exec.Cmd {
-	cmd := exec.Command(name, arg...)
+func (c *LocalRunnerClient) cmd(ctx context.Context, name string, arg ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, arg...)
 	cmd.Env = append(os.Environ(), "K6_CLOUD_TOKEN="+c.token)
 
 	return cmd

--- a/pkg/k6/cmd.go
+++ b/pkg/k6/cmd.go
@@ -37,6 +37,13 @@ func (tr *DefaultTestRun) PID() int {
 	return -1
 }
 
+func (tr *DefaultTestRun) Exited() bool {
+	if tr.Cmd != nil && tr.Cmd.ProcessState != nil {
+		return tr.Cmd.ProcessState.Exited()
+	}
+	return false
+}
+
 func (c *LocalRunnerClient) Start(scriptContent string, upload bool, envVars map[string]string, outputWriter io.Writer) (TestRun, error) {
 	tempFile, err := os.CreateTemp("", "k6-script")
 	if err != nil {

--- a/pkg/k6/cmd.go
+++ b/pkg/k6/cmd.go
@@ -19,6 +19,24 @@ func NewLocalRunnerClient(token string) (Client, error) {
 	return client, nil
 }
 
+type DefaultTestRun struct {
+	*exec.Cmd
+}
+
+func (tr *DefaultTestRun) Kill() error {
+	if tr.Cmd != nil && tr.Cmd.Process != nil {
+		return tr.Cmd.Process.Kill()
+	}
+	return nil
+}
+
+func (tr *DefaultTestRun) PID() int {
+	if tr.Cmd != nil && tr.Cmd.Process != nil {
+		return tr.Cmd.Process.Pid
+	}
+	return -1
+}
+
 func (c *LocalRunnerClient) Start(scriptContent string, upload bool, envVars map[string]string, outputWriter io.Writer) (TestRun, error) {
 	tempFile, err := os.CreateTemp("", "k6-script")
 	if err != nil {
@@ -44,7 +62,7 @@ func (c *LocalRunnerClient) Start(scriptContent string, upload bool, envVars map
 	}
 
 	log.Debugf("launching 'k6 %s'", strings.Join(args, " "))
-	return cmd, cmd.Start()
+	return &DefaultTestRun{cmd}, cmd.Start()
 }
 
 func (c *LocalRunnerClient) cmd(name string, arg ...string) *exec.Cmd {

--- a/pkg/k6/interface.go
+++ b/pkg/k6/interface.go
@@ -5,6 +5,7 @@ package k6
 import (
 	"context"
 	"io"
+	"time"
 )
 
 type Client interface {
@@ -16,4 +17,6 @@ type TestRun interface {
 	Kill() error
 	PID() int
 	Exited() bool
+	ExitCode() int
+	ExecutionDuration() time.Duration
 }

--- a/pkg/k6/interface.go
+++ b/pkg/k6/interface.go
@@ -3,11 +3,12 @@ package k6
 //go:generate mockgen -destination=../mocks/mock_k6_client.go -package=mocks -mock_names=Client=MockK6Client,TestRun=MockK6TestRun github.com/grafana/flagger-k6-webhook/pkg/k6 Client,TestRun
 
 import (
+	"context"
 	"io"
 )
 
 type Client interface {
-	Start(scriptContent string, upload bool, envVars map[string]string, outputWriter io.Writer) (TestRun, error)
+	Start(ctx context.Context, scriptContent string, upload bool, envVars map[string]string, outputWriter io.Writer) (TestRun, error)
 }
 
 type TestRun interface {

--- a/pkg/k6/interface.go
+++ b/pkg/k6/interface.go
@@ -14,4 +14,5 @@ type TestRun interface {
 	Wait() error
 	Kill() error
 	PID() int
+	Exited() bool
 }

--- a/pkg/k6/interface.go
+++ b/pkg/k6/interface.go
@@ -12,4 +12,6 @@ type Client interface {
 
 type TestRun interface {
 	Wait() error
+	Kill() error
+	PID() int
 }

--- a/pkg/mocks/mock_k6_client.go
+++ b/pkg/mocks/mock_k6_client.go
@@ -73,6 +73,34 @@ func (m *MockK6TestRun) EXPECT() *MockK6TestRunMockRecorder {
 	return m.recorder
 }
 
+// Kill mocks base method.
+func (m *MockK6TestRun) Kill() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Kill")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Kill indicates an expected call of Kill.
+func (mr *MockK6TestRunMockRecorder) Kill() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kill", reflect.TypeOf((*MockK6TestRun)(nil).Kill))
+}
+
+// PID mocks base method.
+func (m *MockK6TestRun) PID() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PID")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// PID indicates an expected call of PID.
+func (mr *MockK6TestRunMockRecorder) PID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PID", reflect.TypeOf((*MockK6TestRun)(nil).PID))
+}
+
 // Wait mocks base method.
 func (m *MockK6TestRun) Wait() error {
 	m.ctrl.T.Helper()

--- a/pkg/mocks/mock_k6_client.go
+++ b/pkg/mocks/mock_k6_client.go
@@ -5,6 +5,7 @@
 package mocks
 
 import (
+	context "context"
 	io "io"
 	reflect "reflect"
 
@@ -36,18 +37,18 @@ func (m *MockK6Client) EXPECT() *MockK6ClientMockRecorder {
 }
 
 // Start mocks base method.
-func (m *MockK6Client) Start(arg0 string, arg1 bool, arg2 map[string]string, arg3 io.Writer) (k6.TestRun, error) {
+func (m *MockK6Client) Start(arg0 context.Context, arg1 string, arg2 bool, arg3 map[string]string, arg4 io.Writer) (k6.TestRun, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Start", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(k6.TestRun)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockK6ClientMockRecorder) Start(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockK6ClientMockRecorder) Start(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockK6Client)(nil).Start), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockK6Client)(nil).Start), arg0, arg1, arg2, arg3, arg4)
 }
 
 // MockK6TestRun is a mock of TestRun interface.

--- a/pkg/mocks/mock_k6_client.go
+++ b/pkg/mocks/mock_k6_client.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	io "io"
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 	k6 "github.com/grafana/flagger-k6-webhook/pkg/k6"
@@ -72,6 +73,34 @@ func NewMockK6TestRun(ctrl *gomock.Controller) *MockK6TestRun {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockK6TestRun) EXPECT() *MockK6TestRunMockRecorder {
 	return m.recorder
+}
+
+// ExecutionDuration mocks base method.
+func (m *MockK6TestRun) ExecutionDuration() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExecutionDuration")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// ExecutionDuration indicates an expected call of ExecutionDuration.
+func (mr *MockK6TestRunMockRecorder) ExecutionDuration() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecutionDuration", reflect.TypeOf((*MockK6TestRun)(nil).ExecutionDuration))
+}
+
+// ExitCode mocks base method.
+func (m *MockK6TestRun) ExitCode() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExitCode")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// ExitCode indicates an expected call of ExitCode.
+func (mr *MockK6TestRunMockRecorder) ExitCode() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExitCode", reflect.TypeOf((*MockK6TestRun)(nil).ExitCode))
 }
 
 // Exited mocks base method.

--- a/pkg/mocks/mock_k6_client.go
+++ b/pkg/mocks/mock_k6_client.go
@@ -73,6 +73,20 @@ func (m *MockK6TestRun) EXPECT() *MockK6TestRunMockRecorder {
 	return m.recorder
 }
 
+// Exited mocks base method.
+func (m *MockK6TestRun) Exited() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Exited")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Exited indicates an expected call of Exited.
+func (mr *MockK6TestRunMockRecorder) Exited() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exited", reflect.TypeOf((*MockK6TestRun)(nil).Exited))
+}
+
 // Kill mocks base method.
 func (m *MockK6TestRun) Kill() error {
 	m.ctrl.T.Helper()

--- a/pkg/server.go
+++ b/pkg/server.go
@@ -19,6 +19,7 @@ func Listen(client k6.Client, kubeClient kubernetes.Interface, slackClient slack
 	if err != nil {
 		return err
 	}
+	defer launchHandler.Close()
 
 	serveAddress := fmt.Sprintf(":%d", port)
 	logrus.Info("starting server at " + serveAddress)

--- a/pkg/server.go
+++ b/pkg/server.go
@@ -14,8 +14,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func Listen(client k6.Client, kubeClient kubernetes.Interface, slackClient slack.Client, port int) error {
-	launchHandler, err := handlers.NewLaunchHandler(client, kubeClient, slackClient)
+func Listen(client k6.Client, kubeClient kubernetes.Interface, slackClient slack.Client, port int, maxProcessHandlers int) error {
+	launchHandler, err := handlers.NewLaunchHandler(client, kubeClient, slackClient, maxProcessHandlers)
 	if err != nil {
 		return err
 	}

--- a/pkg/server.go
+++ b/pkg/server.go
@@ -1,8 +1,10 @@
 package pkg
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/grafana/flagger-k6-webhook/pkg/handlers"
 	"github.com/grafana/flagger-k6-webhook/pkg/k6"
@@ -14,20 +16,39 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func Listen(client k6.Client, kubeClient kubernetes.Interface, slackClient slack.Client, port int, maxProcessHandlers int) error {
-	launchHandler, err := handlers.NewLaunchHandler(client, kubeClient, slackClient, maxProcessHandlers)
+func Listen(ctx context.Context, client k6.Client, kubeClient kubernetes.Interface, slackClient slack.Client, port int, maxProcessHandlers int) error {
+	launcherCtx, cancelLaunchCtx := context.WithCancel(ctx)
+	launchHandler, err := handlers.NewLaunchHandler(launcherCtx, client, kubeClient, slackClient, maxProcessHandlers)
+	defer func() {
+		logrus.Debug("shutting down launch handler")
+		cancelLaunchCtx()
+		launchHandler.Wait()
+	}()
 	if err != nil {
 		return err
 	}
-	defer launchHandler.Close()
 
 	serveAddress := fmt.Sprintf(":%d", port)
 	logrus.Info("starting server at " + serveAddress)
 
-	http.HandleFunc("/health", handlers.HandleHealth)
-	http.Handle("/metrics", promhttp.Handler())
+	mux := http.NewServeMux()
+	srv := http.Server{
+		Handler: mux,
+		Addr:    serveAddress,
+	}
 
-	http.Handle("/launch-test",
+	go func() {
+		<-ctx.Done()
+		cancelLaunchCtx()
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+		defer cancel()
+		_ = srv.Shutdown(timeoutCtx)
+	}()
+
+	mux.HandleFunc("/health", handlers.HandleHealth)
+	mux.Handle("/metrics", promhttp.Handler())
+
+	mux.Handle("/launch-test",
 		promhttp.InstrumentHandlerCounter(
 			promauto.NewCounterVec(
 				prometheus.CounterOpts{
@@ -40,5 +61,5 @@ func Listen(client k6.Client, kubeClient kubernetes.Interface, slackClient slack
 		),
 	)
 
-	return http.ListenAndServe(serveAddress, nil)
+	return srv.ListenAndServe()
 }


### PR DESCRIPTION
The idea here is to register k6 TestRuns, for which we do not want to wait for a result, with a cleanup routine so that no zombie processes stay around.

Right now the number of handler go-routines (those that wait for the TestRun processes) are limited in number. If that limit is reached, then the HTTP handler becomes blocking.

```[tasklist]
### Tasks
- [x] Make go-routine limit configurable
- [x] Test-cases for the process handlers
``` 

Resolves #152 