### PR TITLE
fix: Clean up process context if available

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,4 +25,6 @@ linters:
     - revive
 linters-settings:
   gocyclo:
-    min-complexity: 15
+    # Original value: 15. Temporarily increased before a refactoring of
+    # launcher.ServeHTTP.
+    min-complexity: 18

--- a/pkg/handlers/launch.go
+++ b/pkg/handlers/launch.go
@@ -486,7 +486,6 @@ func (h *launchHandler) propagateCancel(req *http.Request, payload *launchPayloa
 		<-h.ctx.Done()
 		cancelCtx()
 	}
-	log.Info("canceling process")
 }
 
 func (h *launchHandler) waitForOutputPath(cmdLog *log.Entry, buf *bytes.Buffer) error {

--- a/pkg/handlers/launch_test.go
+++ b/pkg/handlers/launch_test.go
@@ -671,6 +671,8 @@ func TestProcessHandler(t *testing.T) {
 			tr.EXPECT().Wait().Return(nil).Times(1)
 			tr.EXPECT().Exited().Return(true).AnyTimes()
 			tr.EXPECT().ExitCode().Return(0).AnyTimes()
+			tr.EXPECT().SetCancelFunc(gomock.Any()).Return().AnyTimes()
+			tr.EXPECT().CleanupContext().Return().AnyTimes()
 			tr.EXPECT().ExecutionDuration().Return(time.Minute).AnyTimes()
 			handler.registerProcessCleanup(tr)
 		}
@@ -773,6 +775,8 @@ func setupHandlerWithKubernetesObjects(t *testing.T, maxConcurrentTests int, exp
 	// value here:
 	testRun.EXPECT().ExecutionDuration().Return(time.Minute).AnyTimes()
 	testRun.EXPECT().ExitCode().Return(0).AnyTimes()
+	testRun.EXPECT().SetCancelFunc(gomock.Any()).Return().AnyTimes()
+	testRun.EXPECT().CleanupContext().Return().AnyTimes()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	handler, err := NewLaunchHandler(ctx, k6Client, kubeClient, slackClient, maxConcurrentTests)

--- a/pkg/k6/cmd.go
+++ b/pkg/k6/cmd.go
@@ -23,8 +23,9 @@ func NewLocalRunnerClient(token string) (Client, error) {
 
 type DefaultTestRun struct {
 	*exec.Cmd
-	startedAt time.Time
-	exitedAt  time.Time
+	startedAt     time.Time
+	exitedAt      time.Time
+	cancelContext context.CancelFunc
 }
 
 func (tr *DefaultTestRun) Start() error {
@@ -44,6 +45,12 @@ func (tr *DefaultTestRun) ExitCode() int {
 		return tr.Cmd.ProcessState.ExitCode()
 	}
 	return -1
+}
+
+func (tr *DefaultTestRun) CleanupContext() {
+	if tr.cancelContext != nil {
+		tr.cancelContext()
+	}
 }
 
 func (tr *DefaultTestRun) ExecutionDuration() time.Duration {
@@ -72,6 +79,10 @@ func (tr *DefaultTestRun) Exited() bool {
 		return tr.Cmd.ProcessState.Exited()
 	}
 	return false
+}
+
+func (tr *DefaultTestRun) SetCancelFunc(fn context.CancelFunc) {
+	tr.cancelContext = fn
 }
 
 func (c *LocalRunnerClient) Start(ctx context.Context, scriptContent string, upload bool, envVars map[string]string, outputWriter io.Writer) (TestRun, error) {

--- a/pkg/k6/interface.go
+++ b/pkg/k6/interface.go
@@ -19,4 +19,6 @@ type TestRun interface {
 	Exited() bool
 	ExitCode() int
 	ExecutionDuration() time.Duration
+	CleanupContext()
+	SetCancelFunc(context.CancelFunc)
 }

--- a/pkg/mocks/mock_k6_client.go
+++ b/pkg/mocks/mock_k6_client.go
@@ -75,6 +75,18 @@ func (m *MockK6TestRun) EXPECT() *MockK6TestRunMockRecorder {
 	return m.recorder
 }
 
+// CleanupContext mocks base method.
+func (m *MockK6TestRun) CleanupContext() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "CleanupContext")
+}
+
+// CleanupContext indicates an expected call of CleanupContext.
+func (mr *MockK6TestRunMockRecorder) CleanupContext() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CleanupContext", reflect.TypeOf((*MockK6TestRun)(nil).CleanupContext))
+}
+
 // ExecutionDuration mocks base method.
 func (m *MockK6TestRun) ExecutionDuration() time.Duration {
 	m.ctrl.T.Helper()
@@ -143,6 +155,18 @@ func (m *MockK6TestRun) PID() int {
 func (mr *MockK6TestRunMockRecorder) PID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PID", reflect.TypeOf((*MockK6TestRun)(nil).PID))
+}
+
+// SetCancelFunc mocks base method.
+func (m *MockK6TestRun) SetCancelFunc(arg0 context.CancelFunc) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetCancelFunc", arg0)
+}
+
+// SetCancelFunc indicates an expected call of SetCancelFunc.
+func (mr *MockK6TestRunMockRecorder) SetCancelFunc(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCancelFunc", reflect.TypeOf((*MockK6TestRun)(nil).SetCancelFunc), arg0)
 }
 
 // Wait mocks base method.


### PR DESCRIPTION
Before the process context was not cancelled in the asynchronous mode. This should fix this issue and also remove a misleading log-line.