### PR TITLE
dependabot: Group GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,18 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      actions:
+        update-types:
+          - minor
+          - patch
+
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+
   - package-ecosystem: gomod
     directory: /
     schedule:


### PR DESCRIPTION
Since we look for these updates weekly, there will often be multiple. We can group them to save work and manually handle splitting in the hopefully rare cases it's needed.
