### PR TITLE
chore: Bump chart to 1.3.1

### DIFF
--- a/charts/k6-loadtester/Chart.yaml
+++ b/charts/k6-loadtester/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: k6-loadtester
 description: Flagger webhook using k6 to do load testing of the canary before rolling out traffic
 type: application
-version: 1.2.0
-appVersion: "v0.2.0"
+version: 1.3.1
+appVersion: "v0.3.1"
 sources:
   - https://github.com/grafana/flagger-k6-webhook
 keywords:
@@ -17,4 +17,6 @@ maintainers:
 annotations:
   artifacthub.io/changes: |-
     - kind: updated
-      description: Update appVersion to v0.2.0
+      description: Remove apiGroup for ServiceAccount RoleBinding subject
+    - kind: updated
+      description: Update appVersion to v0.3.1


### PR DESCRIPTION
Replaces https://github.com/grafana/flagger-k6-webhook/pull/132