### PR TITLE
ci: lint PR titles

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,20 @@
+name: Lint PR title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+    branches:
+      - main
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: grafana/shared-workflows/actions/lint-pr-title@main
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+


### PR DESCRIPTION
This should prevent PRs from getting merged that don't use convention commit messages as titles. Eventually, we might generate changelogs and release-versions out of this.

Until shared workflow actions have their own versioning, this will probably only be pinned to the main branch.