### PR TITLE
fix: fix syntax in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ FROM alpine:3.20
 COPY --from=build /app/flagger-k6-webhook /usr/bin/flagger-k6-webhook
 COPY --from=grafana/k6 /usr/bin/k6 /usr/bin/k6
 
-ENTRYPOINT /usr/bin/flagger-k6-webhook
+ENTRYPOINT ["/usr/bin/flagger-k6-webhook"]
 USER 65534


### PR DESCRIPTION
Fixes the https://docs.docker.com/reference/build-checks/json-args-recommended/ build check warning. This also slightly changes the semantics of the call as the Go binary is now directly PID 1 instead of going through an implicit shell, but this shouldn't be an issue IMO.