### PR TITLE
ci: run checks on merge group

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,7 @@
 name: Build and Test
 
 on:
+  merge_group:
   pull_request:
 
 permissions:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: Docker
 
 on:
+  merge_group:
   pull_request:
   push:
     tags:
@@ -82,10 +83,11 @@ jobs:
       - name: Export digest
         id: digest
         if: github.event_name != 'pull_request'
-        run: | # zizmor: ignore[template-injection] docker/build-push-action output
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"          
+          touch "/tmp/digests/${DIGEST#sha256:}"
           echo "artifact_name=digests-${{ matrix.platform }}" | sed -e 's/\//-/g' >> "$GITHUB_OUTPUT"
 
       - name: Upload digest

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,6 +1,7 @@
 name: Lint PR title
 
 on:
+  merge_group:
   pull_request:
     types:
       - opened


### PR DESCRIPTION
Breakage like #254 could be avoided if we use the merge queue to run CI
again before changes go to `main`.
