### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete regular expression for hostnames

### DIFF
--- a/pkg/handlers/launch.go
+++ b/pkg/handlers/launch.go
@@ -28,7 +28,7 @@ const (
 )
 
 // https://regex101.com/r/OZwd8Y/1
-var outputRegex = regexp.MustCompile(`output: cloud \((?P<url>https:\/\/((app\.k6\.io)|([^/]+\.grafana.net\/a\/k6-app))\/runs\/\d+)\)`)
+var outputRegex = regexp.MustCompile(`output: cloud \((?P<url>https:\/\/((app\.k6\.io)|([^/]+\.grafana\.net\/a\/k6-app))\/runs\/\d+)\)`)
 
 type launchPayload struct {
 	flaggerWebhook


### PR DESCRIPTION
Potential fix for [https://github.com/grafana/flagger-k6-webhook/security/code-scanning/1](https://github.com/grafana/flagger-k6-webhook/security/code-scanning/1)

To fix the issue, the dot (`.`) before `net` in the regular expression should be escaped to ensure it matches only a literal dot and not any character. This can be done by replacing `\.grafana.net` with `\.grafana\.net`. Additionally, using a raw string literal (`...`) for the regular expression can simplify escaping and improve readability.

The change should be made in the `outputRegex` variable definition on line 31 in the file `pkg/handlers/launch.go`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
