### PR TITLE
ci: only create local Docker image in PR context

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,11 +92,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           outputs: |
             type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
-            type=docker,name=testimage
+            ${{ github.event_name == 'pull_request' && 'type=docker,name=testimage' || ''}}
           build-args: |
             GO_LDFLAGS=-X github.com/prometheus/common/version.Revision=${{ steps.checkout.outputs.commit }} -X github.com/prometheus/common/version.Version=${{ steps.version.outputs.binary_version }}
 
       - name: Print binary version
+        if: github.event_name == 'pull_request'
         run: |
           docker run --rm "testimage:latest" --version
 


### PR DESCRIPTION
The previous change broke the docker/merge stage most likely due to multiple build outputs. This change now only generates the second output if merge is not performed.