### PR TITLE
chore: disable update of tag in chart values

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "packageRules": [
+        {
+            "description": "The tag should stay empty within the Chart values",
+            "matchFileNames": [
+                "charts/k6-loadtester/values.yaml"
+            ],
+            "matchDepNames": [
+                "ghcr.io/grafana/flagger-k6-webhook"
+            ],
+            "enabled": false
+        }
+    ]
+}


### PR DESCRIPTION
This field should always stay empty so that the default version can be used.