### PR TITLE
fix: scope auto-release PR to charts/ directory only

### DIFF
--- a/.github/workflows/auto-release-chart.yml
+++ b/.github/workflows/auto-release-chart.yml
@@ -112,6 +112,7 @@ jobs:
 
             - Updates `appVersion` to `${{ steps.newest-semver-image.outputs.tag }}`
             - Bumps chart `version` from `${{ steps.current.outputs.chart_version }}` to `${{ steps.new-version.outputs.chart_version }}`
+          add-paths: charts/
           branch: auto-release-chart/${{ steps.newest-semver-image.outputs.tag }}
           base: main
           labels: |


### PR DESCRIPTION
## Summary
Add `add-paths: charts/` to the `peter-evans/create-pull-request` step in the auto-release-chart workflow. The `create-github-app-token` composite action clones shared workflows into a `_shared-workflows-create-github-app-token` directory at the workspace root. Without `add-paths`, this artifact gets committed to the auto-release branch, which breaks checkout in downstream CI jobs (exit code 128, missing submodule URL).

## Test
- Verified PR #450 fails due to this artifact being committed
- After this fix, only files under `charts/` will be staged by `create-pull-request`

## Issue
Fixes failing CI on #450