### PR TITLE
fix: enable signed commits in auto-release-chart workflow

### DIFF
--- a/.github/workflows/auto-release-chart.yml
+++ b/.github/workflows/auto-release-chart.yml
@@ -105,6 +105,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.get-github-app-token.outputs.token }}
+          sign-commits: true
           commit-message: "chore: update chart to ${{ steps.newest-semver-image.outputs.tag }}"
           title: "chore: release chart for ${{ steps.newest-semver-image.outputs.tag }}"
           body: |


### PR DESCRIPTION
## Summary
Enable `sign-commits: true` on `peter-evans/create-pull-request` in the auto-release-chart workflow. The Grafana org now enforces `required_signatures` on all commits, and without this flag the workflow creates unsigned commits that block PRs from merging (e.g. #457).

With `sign-commits: true`, the action creates commits via the GitHub API instead of local git, and GitHub signs them with the App token's identity — no GPG key setup needed.

This is the same approach used across `grafana/grafana`, `grafana/mimir`, `grafana/tempo`, `grafana/beyla`, `grafana/k6-operator`, and `deployment_tools`.

## Test
After merging, re-trigger the `Auto Release Chart` workflow via `workflow_dispatch`. The new PR it creates should have verified/signed commits.

## Issue
Fixes #457 (blocked by unsigned commits)