### PR TITLE
chore: group Go dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,11 @@
       "matchPackageNames": [
         "k8s.io/**"
       ]
+    },
+    {
+      "groupName": "Go dependencies",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch", "digest"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Group non-major Go dependency updates into one Renovate PR to reduce repeated go.mod and go.sum conflicts.

- Include minor, patch, and digest updates
- Keep major updates separate